### PR TITLE
Add rocket reservation and cancellation of reservation

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -94,3 +94,18 @@ li {
   margin-top: 0%;
   margin-bottom: 0%;
 }
+
+.reserved-span {
+  background-color: #5799aa;
+  border-radius: 5px;
+  border: none;
+  color: white;
+}
+
+.unreserve-btn {
+  width: 150px;
+  height: 30px;
+  background-color: white;
+  border-radius: 5px;
+  color: black;
+}

--- a/src/pages/RocketsCards.js
+++ b/src/pages/RocketsCards.js
@@ -1,7 +1,11 @@
 /* eslint no-unused-vars : 'off' */
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { getRocket } from '../redux/rockets/rockets.js';
+import {
+  getRocket,
+  reserveRocket,
+  unreserveRocket,
+} from '../redux/rockets/rockets.js';
 
 const RocketsCards = () => {
   const dispatch = useDispatch();
@@ -20,12 +24,21 @@ const RocketsCards = () => {
     }
   }, []);
 
+  const reserveRockets = (e) => {
+    dispatch(reserveRocket(e.target.id));
+  };
+
+  const unReserveRockets = (e) => {
+    dispatch(unreserveRocket(e.target.id));
+  };
+
   return (
     <div className='rocket-card'>
       {myRocketArray.map((rocket) => (
         <div key={rocket.id} className='rockets-div'>
           <div className='rocket-imgs'>
-            <img src={rocket.flickr_images}
+            <img
+              src={rocket.flickr_images}
               alt={rocket.rocket_name}
               width='300'
               height='200'
@@ -36,9 +49,28 @@ const RocketsCards = () => {
           <div className='rockets-desc'>
             <h3 className='rockets-desc-title'>{rocket.rocket_name}</h3>
             <p className='rockets-desc-p'>
+              {rocket.reserved ? <button className='reserved-span'>Reserved</button> : null}
               {rocket.description}
             </p>
-            <button className='rockets-desc-btn'>Reserve Rocket</button>
+            {rocket.reserved ? (
+              <button
+                type='button'
+                onClick={unReserveRockets}
+                id={rocket.id}
+                className='unreserve-btn'
+              >
+                Cancel Reservation
+              </button>
+            ) : (
+              <button
+              type='button'
+              className='rockets-desc-btn'
+              onClick={reserveRockets}
+              id={rocket.id}
+            >
+              Reserve Rocket
+            </button>
+            )}
           </div>
         </div>
       ))}

--- a/src/redux/rockets/rockets.js
+++ b/src/redux/rockets/rockets.js
@@ -1,5 +1,7 @@
 /* eslint no-unused-vars : "off" */
 const GET_ROCKET = 'GET_ROCKET';
+const RESERVE_ROCKET = 'RESERVE_ROCKET';
+const UNRESERVE_ROCKET = 'UNRESERVE_ROCKET';
 const initialState = [];
 
 export const getRocket = (payload) => ({
@@ -7,8 +9,28 @@ export const getRocket = (payload) => ({
   payload,
 });
 
+export const reserveRocket = (payload) => ({
+  type: RESERVE_ROCKET,
+  payload,
+});
+
+export const unreserveRocket = (payload) => ({
+  type: UNRESERVE_ROCKET,
+  payload,
+});
+
 const reducer = (state = initialState, action) => {
   switch (action.type) {
+    case RESERVE_ROCKET:
+      return state.map((rocket) => {
+        if (rocket.id !== parseInt(action.payload, 10)) return rocket;
+        return { ...rocket, reserved: true };
+      });
+    case UNRESERVE_ROCKET:
+      return state.map((rocket) => {
+        if (rocket.id !== parseInt(action.payload, 10)) return rocket;
+        return { ...rocket, reserved: false };
+      });
     case GET_ROCKET:
       return action.payload.map((key) => ({
         id: key.id,


### PR DESCRIPTION
In this section I have implemented the following:
- When a user clicks the "Reserve rocket" button, an action is dispatched to update the store. The ID of the reserved rocket is gotten and the state is updated.

- When a user clicks on the "Cancel Reservation" an action is dispatched to update the store. The ID of the reserved rocket is gotten and the state is updated to set the reserved key to false.

- Rockets that have already been reserved show a "Reserved" badge and "Cancel reservation" button instead of the default "Reserve rocket"